### PR TITLE
[FIX] Must use import to load ES Module: /app/src/setupProxy.js, requ…

### DIFF
--- a/src/setupProxy.cjs
+++ b/src/setupProxy.cjs
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-const { createProxyMiddleware } = require('http-proxy-middleware');
+import { createProxyMiddleware } from 'http-proxy-middleware';
 
 module.exports = (app) => {
   app.use(


### PR DESCRIPTION
…ire() of ES modules is not supported.